### PR TITLE
content: Improve phrasing of DCF Postmortem & Pobail Retro.

### DIFF
--- a/src/writing/dublin-circus-postmorterm.md
+++ b/src/writing/dublin-circus-postmorterm.md
@@ -31,7 +31,7 @@ At the time the only other circus society with this responsibility was the Galwa
 The primary strength and weakness of all college societies is turnover rate, which was a very important part of my planning strategy during my involvement with the circus festival and the circus society.
 
 # The Plan
-Although I had not been previously involved with running the festival, I liked the idea that it was ran collabartively between the circus societies of Dublin. Besides the societies, there is also the Dublin Circus Project who'd helped run it in previous years. Each "organisation" held different strengths and resources to bring to the festival.
+Although I had not been previously involved with running the festival, I liked the idea that it was ran collaboratively between the circus societies of Dublin. Besides the societies, there is also the Dublin Circus Project who'd helped run it in previous years. Each "organisation" held different strengths and resources to bring to the festival.
 
 The biggest concerns  were:
 
@@ -41,9 +41,9 @@ The biggest concerns  were:
 * The renegade show
 * The intersoc games
 
-DIT was inherently responsible for the training space, as it had been Larkin Hall for years, which held a relationship with DIT for use not only by the circus society but also the dance society and the various sports clubs. The fire show was facilitated by Trinity College, who held fire shows most frequently and were the point of contact for the performance space (Trinity Front Square).
+DIT was inherently responsible for the training space, as it had been Larkin Hall for years, which held a relationship with DIT for use not only by the circus society, but also the dance society and the various sports clubs. The fire show was facilitated by Trinity College, who held fire shows most frequently and were the point of contact for the performance space (Trinity Parliament Square).
 
-The gala show venue was The Lir Academy, primarily ran by members of the Dublin Circus Project (Who also participated in the fire show), and finally, the renegade show was held in the basement of Doyle's pub. The games took place in the hall, which was the farthest venue from all the others, but where most of the activities took place.
+The gala show venue was The Lir Academy, ran by members of the Dublin Circus Project (Who also participated in the fire show), and finally, the renegade show was held in the basement of Doyle's pub. The games took place in the hall, which was the farthest venue from all the others, but where people spent most of their time during the event.
 
 Besides the venues and their respective  events, other aspects  we had to worry about included:
 
@@ -53,35 +53,33 @@ Besides the venues and their respective  events, other aspects  we had to worry 
 * Wristbands
 * Game prizes
 
-As the representative from the DIT Circus Society, I budgeted for the event (Necessary as part of the application to get funding from the societies office), acted as the end of the line for venue contact to facilitate payments and organised the monthly meetings for the festival.
+As the representative from the DIT Circus Society, I budgeted for the event (Necessary to get funding from the societies office), acted as the end of the line for venue contact to facilitate payments and organised the monthly meetings for the festival.
 
 Although I stuck to the idea of running the festival as a collaborative effort, I unintentionally became the coordinator while trying to keep all of the individual components moving and communicating as smoothly as possible.
 
 Had I realised this earlier, or started with this role in mind, I think I could've done a better job.
 
 # What went right
-One of the most important things to me was that the hall remain open as long as possible, which is part of why the Galway Juggling Convention is my favourite - managing to run hours from roughly 9am till 11pm. Although the schedule of shows on Saturday meant that the roughly 6PM hall close felt natural, we managed to keep the hall open until 9PM on Friday, meaning that people who were not attending the fire show could continue training.
+One of the most important things to me was that the hall remain open as long as possible, which is part of why the Galway Juggling Convention is my favourite - running hours from roughly 9AM till 11PM. Although the Gala Show on Saturday meant that the roughly 6PM hall close felt natural, we managed to keep the hall open until 9PM on Friday, meaning that people who were not attending the fire show could continue training.
 
-The fire show itself had an unprecedented turnout, gathering a crowd of roughly two thousand people.
-
-Although the nature of the intervarsity games mean they are not seriously competitive, we managed to budget for high quality props as prizes, giving people a more concrete reward for the effort required to finishing on top.
+The fire show itself had an unprecedented turnout, gathering a crowd of roughly two thousand people. While the intervarsity games are not seriously competitive, we budgeted for high quality equipment as prizes, making participation significantly more appealing.
 
 Each of the performers was paid for their involvement with the gala show, which I felt was important. There's a sense of collaboration and contribution in the community; typically performers will do acts as part of conventions for free as a way of giving back (Besides teaching) as many people get their start through the support network offered by the community and college societies.
 
-I felt that although this was perceived as a fair arrangement by performers, the expectations of someone doing prop-based performance versus aerial performance meant that the financial investment in working on skills could be vastly different, but that ensuring everyone was paid equally was favourable over preferential treatment.
+Although this was perceived as a fair arrangement by performers, the expectations of someone doing prop-based performance versus aerial performance meant that the financial investment in working on skills could be vastly different, so ensuring everyone was paid equally felt more favourable over preferential treatment.
 
 # What went wrong
-The biggest issue to arise during the festival was how pre-bookings were managed in regard to Gala show attendance. The National Circus Festival in Tralee has an afternoon and evening show in Siasma Tire, ensuring that all attending the festival as well as the general public have an opportunity to see the gala show.
+The biggest issue to arise during the festival was how pre-bookings were managed for Gala Show attendance. The National Circus Festival in Tralee has an afternoon and evening show, ensuring that festival attendees as well as the general public have an opportunity to see the gala show.
 
 The venue used for the Dublin Circus Festival had a seating capacity of around 150 people, while the festival attendees numbered just over 210. As the festival was already using online registration to reduce the liability of handling a large amount of cash, it made sense to also use it to prioritise seating since pre-registration gives organisers a better projection of attendance numbers.
 
-However, miscommunication occured between committee members, leading many to believe that preregistration didn't matter while others did, which was subsequently disseminated incorrectly to the public in the lead up to the event, causing lots of confusion at the registration desk.
+However, miscommunication occured between committee members, leading many to believe that pre-registration didn't matter while others did, which was subsequently disseminated incorrectly to the public in the lead up to the event. This caused lots of confusion and frustration at check-in.
 
 This later lead a committee member to use the registration book to talk to registrants based on their sign-in order to try figure out if they wanted to attend the gala show, triaging the mistake by prioritising those who pre-registered, then those in order of appearance in the book.
 
 The other largest concern was the fire show, as we were unable to lock down availability as it was dependent on when Trinity Ball would take place, which would make the entire campus unavailable.
 
-There was also some miscommunication with who was supposed to book the space, meaning that the bureacracy involved required didn't start until far later, which might have also affected the amount of fire stewards available for the unprecedented amount of people attending the show beside the Campanile in Trinity Front Square.
+There was miscommunication about who was supposed to book the space, meaning that the bureacracy involved required didn't start until far later, which could have have affected the amount of fire stewards available for  what became an unprecedented amount of people attending the show.
 
 # What I learned
 I had two major realisations following the event about what my responsibilities should've been as the coordinator.
@@ -94,10 +92,10 @@ This is something to keep in mind for any efforts involving volunteers - althoug
 
 Secondly, that you need to primarily focus on the responsibility of coordinating as a coordinator. Since I was the representative for DIT I spent a lot of time on the desk so I could handle the money, but I didn't check in with the crew at different venues to see if they needed anything.
 
-It's a straightforward example of something I could've delegated to another DIT committee member, as had I instead focused on following up with commitee members before and during the event, I could've headed off problems before they occured, such as the pre-registration issue for gala show seating.
+This is something I could've delegated to another DIT committee member, as had I instead focused on following up with commitee members before and during the event, I could've headed off problems before they occured, such as the pre-registration issue for gala show seating.
 
 # What I left behind
-Throughout the entire planning process for the festival, as well as my involvement with the DIT Circus Society, I dedicated a significant amount of time documenting the processes and factors required to run the event. I felt it was important to be transparent since the festival was a collaborative event, but I also did so with the intention of making it easier for someone else to take over in the future.
+Throughout the planning process for the festival, as well as my involvement with the DIT Circus Society, I dedicated a significant amount of time documenting the processes and factors required to run the event. I felt it was important to be transparent since the festival was a collaborative event, but I also did so with the intention of making it easier for someone else to take over in the future.
 
 The ephemereal nature of college societies means that although many people stick to one or two societies while working on their degree, upon completion many may not return nor can be involved with running them. This means that societies have a slow but devastating turnover rate every four years, greatly impacting how a society will be run.
 
@@ -105,4 +103,4 @@ By leaving as much documentation as possible, it better prepares the next iterat
 
 Funding from individual colleges allows for many events to be organised that might not be otherwise, but also limits the amount of growth potential based on the constantly adjusting budgets of each society and the larger fund allocated for events by colleges. "Profit" from events cannot be reinvested, and is instead used to absorb the loss of other unrelated events and societies.
 
-By leaving behind as large and comprehensive an amount of documentation as I could, it ensured that the festival could continue to run into the future, or could aid in organising other events, reducing the proliferation of the bus factor when overreliance of individuals happens in various projects.
+By leaving behind as large and comprehensive an amount of documentation as I could, it ensured that the festival could continue to run into the future, and could aid in organising other events, reducing the bus factor when overreliance of individuals happens in various projects.

--- a/src/writing/pobail-retrospective.md
+++ b/src/writing/pobail-retrospective.md
@@ -26,7 +26,7 @@ The reality is that the circus community is more than just people who perform it
 
 It's groups coming together collectively to perform shows, to run classes, and to plan events as small as 80 people in a hall to 2,000 people at a campsite. What brings all of these people together is a sense of empathy and familiarity. A somewhat laissez-faire approach to getting things done: a lack of drive, but also of animosity.
 
-Everyone is friendly, and there's no real sense of hierarchy. An international performer doing highly technical tricks on a gala show stage will be in the same line as you at the closest burrito bar to the venue. You might end up napping in a pile alongside them the following day. That night, a stranger might regurgitate a shot of tequila into your mouth during a renegade show.
+Everyone is friendly, and there's no real sense of hierarchy. An international performer doing highly technical tricks on a gala show stage will be in the same line as you at the closest burrito bar to the venue. You could end up napping in a pile alongside them the following day. That night, a stranger might regurgitate a shot of tequila into your mouth during a renegade show.
 
 The state of affairs is relaxed, and although there is deference to the full time performers dedicated to their craft, or organisers facilitating the spaces the community congregates in, everyone is essentially treated the same: a well intentioned, infrequently employed vagrant with a heart of gold.
 
@@ -72,11 +72,11 @@ My weekly busy night became free. A fortnight later, I visited a friend across t
 
 ## Lockdown Reflection
 
-In the years before COVID-19 bludgeoned international dance communities, we'd dance outdoors (roughly) once a month on a bandstand in a park. When restrictions eased up, people started meeting up and dancing outdoors - on an unofficial basis, of course. This was an ad-hoc effort organised by a handful of people, and through it, we slowly got a picture of who was still around.
+In the summers before COVID-19 bludgeoned international dance communities, once a month (roughly) we'd dance on a bandstand in a park. When restrictions eased up, people started meeting up and dancing outdoors - on an unofficial basis, of course. This was an ad-hoc effort organised by a handful of people, and through it, we slowly got a picture of who was still around.
 
 A lot of people left Dublin during lockdown, if not the country altogether. The scene had a hard reset: there was a group of existing dancers who might not have socialised much in the past, a bunch of migrant dancers trying to make local connections, and a few people trying it for the first time through the limited classes available.
 
-We'd dance once or twice a weekend outdoors, then go for some drinks afterwards. The organisers I originally took classes from decided it was time to throw in the towel, and asked if I was interested in taking over. After many years taking a backseat in the community, I decided I was willing to step back up - and had a vision. It was an opportunity to build something better.
+We'd dance once or twice a weekend outdoors, then go for some drinks afterwards. The organisers I originally took classes from decided [it was time to throw in the towel](https://www.facebook.com/groups/213020498710404/posts/4634837796528630/), and asked if I was interested in taking over. After many years taking a backseat in the community, I decided I was willing to step back up - and had a vision. It was an opportunity to build something better.
 
 I had made a lot of mistakes in the past, and tried to warn people away from doing the same. Much of the time they didn't listen. I realised my mentality for running events was similar to class planning for an inexperienced teacher. Sometimes you're inclined to focus on describing what can go wrong - in an effort to help people, you air all the greivances you have with how you felt you learned something badly.
 
@@ -128,7 +128,7 @@ If you want a community to feel like a full, coherent collective, you should cre
 
 The second is simply by getting people to talk to each other. In our existing documentation, I try to emphasise that running the door is incredibly important because you're likely giving someone their first impression of the community - and learning the word most important to them in any language: their name. Even the bravest person will feel out of place coming into a new activity, and the more people they know, the more comfortable they will be.
 
-I've read of some scenes designating 'dance ambassadors' who are on-duty during a social dance night to ask new or visiting people to dance. I find this approach absolutely stupid, because I perceive it as patronising - and it doesn't mean they'll actually get to know anybody. Chatting on a dance floor is like taking a first date to a movie - it's not intrinsically designed for you to talk in.
+I've read of some scenes designating 'dance ambassadors' who are on-duty during a social dance night to ask new or visiting people to dance. I find this approach absolutely stupid, because I perceive it as patronising - and it doesn't mean they'll actually get to know anybody. Chatting on a dance floor is like taking a first date to a movie: it's not intrinsically designed for you to talk in.
 
 Go to the pub. I'm not joking. At the end of each dance night, I shout at people to go for drinks so they will 1.) Vacate the venue (And help maintain our good relationship with it) and 2.) Have them sit down in a quieter environment where their attention isn't split. The more people go, the better - especially if they're DJs, teachers and organisers.
 
@@ -136,7 +136,7 @@ We dance with people, not levels. As the established people in a community, it's
 
 ## The Future?
 
-Like an unfamiliar song, I'm never sure if I want to end my writing with a dramatic break or just keep moving until there's no music left to drive me. I'm proud of what I've accomplished since Pobail Stomp started - and it's a very alien feeling for me to acknowledge or accept praise for my involvement with anything. I try to find enjoyment in doing things for the sake of doing them, especially out of principle - and have clashed with others multiple times as a result.
+Like an unfamiliar song, I'm never sure if I want to end my writing with a dramatic break or just keep moving until there's no music left to drive me. I'm proud of what I've accomplished since Pobail Stomp started, and it's a very alien feeling for me to acknowledge or accept praise for my involvement with anything. I try to find enjoyment in doing things for the sake of doing them, especially out of principle - and have clashed with others multiple times as a result.
 
 This year so far has been a nebulous one for me, but I feel confident that I am not a singular bus factor in Dublin's scene. We're wrestling with higher order concerns for community building such as a safety committee, which makes me think it's finally maturing past its awkward pubescent stage. I think there's space to do more, but it's important to establish how we want to do so.
 


### PR DESCRIPTION
There was a few minor grammar issues in the Pobail Stomp retrospective that bothered me: I originally intended to fix a blatant mistake, but I could not find it anywhere.

I'm still unsure how I feel about editing old content: the DCF postmortem is one of the oldest works I have kept online. I found that I referred back to it often, so it felt appropriate to fix it.

It stands as an evergreen measure of how I have changed as an event organiser, but now the grammar makes me cringe less.